### PR TITLE
Make maxmates report limit configurable instead of fixed at 10

### DIFF
--- a/event/backend/stats/maxmates.php
+++ b/event/backend/stats/maxmates.php
@@ -3,8 +3,8 @@ include("../inc/common.php");
 include("../inc/utils.php");
 $vr=verify_right(["admin"=>[null],"data"=>["stat"]]);
 $limit = (int) ($_GET["limit"] ?? 10);
-if ($limit < 10) {
-    $limit = 10;
+if ($limit < 0) {
+    $limit = 0;
 } elseif ($limit > 150) {
     $limit = 150;
 }
@@ -14,7 +14,9 @@ WHERE tm.TripID=Trip.id AND tm.member_id=Member.id AND tmo.TripID=Trip.id AND Me
 AND YEAR(Trip.OutTime)=YEAR(NOW())
 GROUP By Member.id
 ORDER BY rokammerater DESC
-LIMIT ' . $limit . ';';
-';
-$result=$rodb->query($s) or dbErr($rodb,$res,"maxmates");
+LIMIT ?';
+$stmt = $rodb->prepare($s) or dbErr($rodb,$res,"maxmates");
+$stmt->bind_param("i",$limit);
+$stmt->execute() || dbErr($rodb,$res,"maxmates Exe");
+$result= $stmt->get_result();
 process($result,"xlsx","maxmates","_auto");

--- a/event/backend/stats/maxmates.php
+++ b/event/backend/stats/maxmates.php
@@ -2,13 +2,19 @@
 include("../inc/common.php");
 include("../inc/utils.php");
 $vr=verify_right(["admin"=>[null],"data"=>["stat"]]);
+$limit = (int) ($_GET["limit"] ?? 10);
+if ($limit < 10) {
+    $limit = 10;
+} elseif ($limit > 150) {
+    $limit = 150;
+}
 $s='SELECT Concat(Member.FirstName," ",Member.LastName) as roer,Member.MemberID as medlemsnummer,COUNT(distinct tmo.member_id) as rokammerater
 FROM Member, Trip,TripMember tm, TripMember tmo
 WHERE tm.TripID=Trip.id AND tm.member_id=Member.id AND tmo.TripID=Trip.id AND Member.id!=tmo.member_id
 AND YEAR(Trip.OutTime)=YEAR(NOW())
 GROUP By Member.id
 ORDER BY rokammerater DESC
-LIMIT 10;
+LIMIT ' . $limit . ';';
 ';
 $result=$rodb->query($s) or dbErr($rodb,$res,"maxmates");
 process($result,"xlsx","maxmates","_auto");

--- a/rowingapp/frontend/event/controllers/rowing.js
+++ b/rowingapp/frontend/event/controllers/rowing.js
@@ -28,6 +28,7 @@ function rowingCtrl ($scope, $routeParams,$route,$confirm,DatabaseService, Login
   $scope.rowerkm_only_members = false;
   $scope.rowerkm_year = new Date().getFullYear();
   $scope.newright_year = new Date().getFullYear();
+  $scope.maxmates_number = 10;
   $scope.datereservation={"start_time":"17:00","end_time":"19:00"};
   $scope.reservation_match = function() {
     return function(reservation) {

--- a/rowingapp/frontend/event/templates/rowing.html
+++ b/rowingapp/frontend/event/templates/rowing.html
@@ -792,7 +792,8 @@
     <input type="checkbox" ng-model="rowerkm_only_members"/> kun nuværende medlemmer,
     <input type="checkbox" ng-model="rowerkm_force_email"/> inkluder fortrolig email)</li>
   <li><a href="/backend/event/stats/boatrowerkm.php?format=xlsx">Årets 10 mest aktive roere i hver båd som regneark</a></li>
-  <li><a href="/backend/event/stats/maxmates.php?format=xlsx">Årets 10 roere med flest rokammerater som regneark</a></li>
+  <li><a href="/backend/event/stats/maxmates.php?format=xlsx&limit={{maxmates_number}}">Årets roere med flest rokammerater som regneark</a>
+  (antal <input type="number" ng-model="maxmates_number" size="4" min="10" max="150" />)</li>
   <li><a href="/backend/event/stats/longdistancecoxes.php">Langdistancestyrmænd som regneark</a></li>
   <li><a href="/backend/event/stats/instruktorstat.php">Sidste års instruktører som regneark</a>&nbsp;(<a href="/backend/stats/instruktorstat_all.php">sidste 10 år</a>)</li>
   <li><a href="/backend/event/stats/instruktor_entring.php">Instruktøreres entringsøvelser som regneark</a></li>
@@ -805,8 +806,8 @@
   </li>
   <li><a href="/backend/event/stats/swimtest3year.php">Langturssvømmeprøver, 3 år</a></li>
   <li><a href="/backend/event/stats/newrights_year.php?year={{newright_year}}">Nye rettigheder pr. år</a>
-    (år <input type="text" ng-model="newright_year" size="4"/>),
-    <li><a href="/backend/event/stats/trip_stat_year.php?output=xlsx&allboats=1&km=1">km statistik for turtyper mm (robåde, kajakker)</a></li>
+    (år <input type="text" ng-model="newright_year" size="4"/>)</li>
+  <li><a href="/backend/event/stats/trip_stat_year.php?output=xlsx&allboats=1&km=1">km statistik for turtyper mm (robåde, kajakker)</a></li>
   <li><a href="/backend/event/stats/trip_stat_month.php?output=xlsx&allboats=1&km=1">km statistik per måned (robåde, kajakker)</a></li>
   <li><a href="/backend/event/stats/trip_rower_year.php?output=xlsx&allboats=1&km=1">roer statistik for turtyper mm (robåde, kajakker)</a></li>
   <li><a href="/backend/event/stats/rowersbyright.php?right=instructor&subtype=kajak">Kajakinstruktører</a></li>


### PR DESCRIPTION
Updates the "maxmates" report so users can select how many rows to export instead of always getting the top 10 - min. 10 and max 150.